### PR TITLE
fix: button variant

### DIFF
--- a/src/control-center/src/views/HomeView.vue
+++ b/src/control-center/src/views/HomeView.vue
@@ -66,7 +66,7 @@ function simulate() {
     <button class="elm-button" data-variant="brand-primary" title="Simulieren" @click="simulate()">
       Simulieren
     </button>
-    <button class="elm-button" data-variant="brand-secondary" title="Statische Daten laden" @click="loadStaticData()">
+    <button class="elm-button" data-variant="secondary-solid" title="Statische Daten laden" @click="loadStaticData()">
       Statische Daten laden
     </button>
   </div>


### PR DESCRIPTION
there's no `brand-secondary` variant, but most likely you meant `secondary-solid`, compare to https://db-ui.github.io/core/?p=viewall-elements-buttons